### PR TITLE
Fixed ios compatibility (Buffer + deprecated imports)

### DIFF
--- a/packages/nativescript-color-wheel/package.json
+++ b/packages/nativescript-color-wheel/package.json
@@ -28,6 +28,9 @@
 	"bugs": {
 		"url": "https://github.com/SergeyMell/nativescript-plugins/issues"
 	},
+	"dependencies": {
+		"buffer": "6.0.3"
+	},
 	"license": "Apache-2.0",
 	"homepage": "https://github.com/SergeyMell/nativescript-plugins",
 	"readmeFilename": "README.md",

--- a/packages/nativescript-svg/index.ios.ts
+++ b/packages/nativescript-svg/index.ios.ts
@@ -1,9 +1,14 @@
 /// <reference path="../../node_modules/@nativescript/types-ios/index.d.ts" />
 
+import { Buffer } from 'buffer'
+
 import * as svg from '.';
 import * as common from './common';
 import * as types from '@nativescript/core/utils/types';
+import * as utils from '@nativescript/core/utils';
 import * as fs from '@nativescript/core/file-system';
+import { Trace } from '@nativescript/core/trace';
+import { View } from '@nativescript/core/ui/core/view';
 
 export * from './common';
 
@@ -204,8 +209,6 @@ export class SVGImage extends common.SVGImage {
 	}
 
 	public onMeasure(widthMeasureSpec: number, heightMeasureSpec: number): void {
-		const utils = require('utils/utils');
-
 		// We don't call super because we measure native view with specific size.
 		const width = utils.layout.getMeasureSpecSize(widthMeasureSpec);
 		const widthMode = utils.layout.getMeasureSpecMode(widthMeasureSpec);
@@ -231,17 +234,13 @@ export class SVGImage extends common.SVGImage {
 			measureWidth = finiteWidth ? Math.min(resultW, width) : resultW;
 			measureHeight = finiteHeight ? Math.min(resultH, height) : resultH;
 
-			const trace = require('trace');
-
-			if (trace.enabled) {
-				trace.write('nativeWidth: ' + nativeWidth + ', nativeHeight: ' + nativeHeight, trace.categories.Layout);
+			if (Trace.enabled) {
+				Trace.write('nativeWidth: ' + nativeWidth + ', nativeHeight: ' + nativeHeight, Trace.categories.Layout);
 			}
 		}
 
-		const view = require('ui/core/view');
-
-		const widthAndState = view.View.resolveSizeAndState(measureWidth, width, widthMode, 0);
-		const heightAndState = view.View.resolveSizeAndState(measureHeight, height, heightMode, 0);
+		const widthAndState = View.resolveSizeAndState(measureWidth, width, widthMode, 0);
+		const heightAndState = View.resolveSizeAndState(measureHeight, height, heightMode, 0);
 
 		this.setMeasuredDimension(widthAndState, heightAndState);
 	}


### PR DESCRIPTION
Hi :)

I was testing out your plugin with iOS and found deprecated imports (like on Android: https://github.com/SergeyMell/nativescript-plugins/issues/9). I replaced them by the correct ones.

I also found that `Buffer` is included with Node, but is not present in the app when it is executing. So I imported this plugin: https://www.npmjs.com/package/buffer.

It is working so far, I just have an issue with my SVGs not having the correct ratio. I'm actually trying to figure out why but I don't think it is related to this issue.